### PR TITLE
Fix misnamed directory

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -99,4 +99,4 @@ PRODUCT_PROPERTY_OVERRIDES := \
 
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/shinano-common/platform.mk)
-$(call inherit-product, vendor/sony/shinano-sirius/sirius-vendor.mk)
+$(call inherit-product, vendor/sony/sirius/sirius-vendor.mk)


### PR DESCRIPTION
I believe this is the correct fix, although I haven't actually tested it yet.

I'm currently in the process of building for sirius, and my temporary workaround was to symlink `vendor/sony/sirius` to `vendor/sony/shinano-sirius`